### PR TITLE
Improved regular expressions

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ else:
 
 log_activity = False
 
-pattern = re.compile("(?:http[s]?://www\.youtube\.com/watch\?v=|http://youtu.be/)([0-9A-Za-z\-_]*)")
+pattern = re.compile("(?:youtube\.com/watch\?v=|youtu.be/)([0-9A-Za-z\-_]*)")
 
 r = praw.Reddit('youtubefactsbot')
 


### PR DESCRIPTION
People copy YouTube links in a number of ways. Sometimes they include the 'www.', sometimes they submit as 'https'. The new regex finds more legitimate YouTube links.
